### PR TITLE
Update isitup.org call to use https to avoid redirect

### DIFF
--- a/isitup.php
+++ b/isitup.php
@@ -42,7 +42,7 @@ $user_agent = "IsitupForSlack/1.0 (https://github.com/mccreath/istiupforslack; m
 
 # We're just taking the text exactly as it's typed by the user. If it's not a valid domain, isitup.org will respond with a `3`.
 # We want to get the JSON version back (you can also get plain text).
-$url_to_check = "http://isitup.org/".$text.".json";
+$url_to_check = "https://isitup.org/".$text.".json";
 
 # Set up cURL 
 $ch = curl_init($url_to_check);


### PR DESCRIPTION
Looks like isitup.org is forcing https with a redirect if http is used, causing the curl_exec to return a 301 redirect instead of the expected response.

Adding https fixed the problem for me.
